### PR TITLE
Fixes issue where code blocks were missing styling.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -70,7 +70,8 @@ module.exports = {
       resolve: `gatsby-plugin-purgecss`,
       options: {
         printRejected: true, // Print removed selectors and processed file names
-        tailwind: true
+        tailwind: true,
+        ignore: ["prismjs/"]
       }
     },
     {


### PR DESCRIPTION
Adds `prismjs` to the list of ignored directories by purgecss. Because
of the way the CSS seems to work for  for big, language-specific blocks,
it was getting purged, even though it was used. I'm guessing the problem
was there was CSS like `.language*` or something.

By not purging the CSS, it will be rendered as expected when deployed.