### PR TITLE
Creates GH action for deploying.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,15 @@
+name: Gatsby Publish
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: enriikke/gatsby-gh-pages-action@v2
+        with:
+          access-token: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
Uses the [Gatsby Publish](https://github.com/marketplace/actions/gatsby-publish) action from the marketplace to deploy/publish the site on push to develop.

This action will run on pushes to develop since we are using develop as the main branch (and master is where the "deployed" code goes.