### PR TITLE
Adds gatsby plugin for adding links to headers

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -41,7 +41,8 @@ module.exports = {
           {
             resolve: `gatsby-remark-prismjs`
           },
-          `gatsby-remark-copy-linked-files`
+          `gatsby-remark-copy-linked-files`,
+          `gatsby-remark-autolink-headers`
         ]
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4922,7 +4922,7 @@
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
         "readable-stream": "^2.3.5",
@@ -11294,6 +11294,59 @@
           "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
           "requires": {
             "loose-envify": "^1.0.0"
+          }
+        }
+      }
+    },
+    "gatsby-remark-autolink-headers": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-2.2.3.tgz",
+      "integrity": "sha512-xPU2FPniRaNu/9z4szPmkTrx7NlDoaOUTxlPyTSD4vynuphZGBonGMiqb2BOj03RHIeKEvRAp3dhvIMSJ+TPsQ==",
+      "requires": {
+        "@babel/runtime": "^7.8.7",
+        "github-slugger": "^1.3.0",
+        "lodash": "^4.17.15",
+        "mdast-util-to-string": "^1.1.0",
+        "unist-util-visit": "^1.4.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+          "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "emoji-regex": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
+          "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4="
+        },
+        "github-slugger": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.3.0.tgz",
+          "integrity": "sha512-gwJScWVNhFYSRDvURk/8yhcFBee6aFjye2a7Lhb2bUyRulpIoek9p0I9Kt7PT67d/nUlZbFu8L9RLiA0woQN8Q==",
+          "requires": {
+            "emoji-regex": ">=6.0.0 <=6.1.1"
+          }
+        },
+        "mdast-util-to-string": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz",
+          "integrity": "sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+        },
+        "unist-util-visit": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+          "requires": {
+            "unist-util-visit-parents": "^2.0.0"
           }
         }
       }
@@ -19461,7 +19514,7 @@
       "dependencies": {
         "commander": {
           "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "requires": {
             "graceful-readlink": ">= 1.0.0"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gatsby-plugin-react-helmet": "^3.1.18",
     "gatsby-plugin-sharp": "^2.5.1",
     "gatsby-plugin-typescript": "^2.1.23",
+    "gatsby-remark-autolink-headers": "^2.2.3",
     "gatsby-remark-copy-linked-files": "^2.1.33",
     "gatsby-remark-external-links": "0.0.4",
     "gatsby-remark-images": "^3.0.1",


### PR DESCRIPTION
Adds https://www.gatsbyjs.org/packages/gatsby-remark-autolink-headers/
to automatically make links out of headers in blog posts.