### PR TITLE
Adds margin after image tags

### DIFF
--- a/src/css/post.css
+++ b/src/css/post.css
@@ -5,6 +5,7 @@
 .blog-post-body ul,
 .blog-post-body ol,
 .blog-post-body p,
+.blog-post-body img,
 .blog-post-body .gatsby-highlight,
 .blog-post-body .gatsby-resp-image-link {
   @apply mb-4;


### PR DESCRIPTION
Uses margin after other block elements to also apply to `img` tags.

Before:

![Screen Shot 2020-05-11 at 6 42 46 AM](https://user-images.githubusercontent.com/691365/81553128-a13dba80-9352-11ea-933c-f0a68718f944.png)


After:

![Screen Shot 2020-05-11 at 6 41 00 AM](https://user-images.githubusercontent.com/691365/81553042-7fdcce80-9352-11ea-9916-f79ba061d57e.png)
