### PR TITLE
Updates config for purge css.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -72,7 +72,7 @@ module.exports = {
       options: {
         printRejected: true, // Print removed selectors and processed file names
         tailwind: true,
-        ignore: ["prismjs/"]
+        ignore: ["prismjs/", "post.css"]
       }
     },
     {


### PR DESCRIPTION
Updates gatsby-config for Purge CSS to ignore `post.css` file. This file
deals with CSS for the blog posts. Because the HTML doesn't exist until
sometime during the build process, purge CSS (also run during the build
process) thinks the CSS defined in `post.css` isn't being used and
purges it. Since there isn't much there and we should be using most
(all?) of it, this change tells purge CSS to ignore the `post.css` file.
This should enable some of the small CSS tweaks to actually work.