### PR TITLE
Switches to `gatsby-remark-vscode` for code block rendering.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -39,10 +39,14 @@ module.exports = {
           },
           `gatsby-remark-responsive-iframe`,
           {
-            resolve: `gatsby-remark-prismjs`
+            resolve: `gatsby-remark-vscode`,
+            options: {
+              theme: `Tomorrow`,
+              extensions: [`vscode-themes/tomorrow`]
+            },
           },
           `gatsby-remark-copy-linked-files`,
-          `gatsby-remark-autolink-headers`
+          `gatsby-remark-autolink-headers`,
         ]
       }
     },

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "gatsby-remark-copy-linked-files": "^2.1.33",
     "gatsby-remark-external-links": "0.0.4",
     "gatsby-remark-images": "^3.0.1",
-    "gatsby-remark-prismjs": "^3.3.28",
     "gatsby-remark-responsive-iframe": "^2.2.30",
+    "gatsby-remark-vscode": "^3.0.1",
     "gatsby-source-filesystem": "^2.1.43",
     "gatsby-transformer-json": "^2.2.22",
     "gatsby-transformer-remark": "^2.6.45",
@@ -42,7 +42,8 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-helmet": "^5.2.1",
-    "typescript": "^3.7.4"
+    "typescript": "^3.7.4",
+    "vscode-themes": "Microsoft/vscode-themes"
   },
   "devDependencies": {
     "@types/node": "^10.17.13",


### PR DESCRIPTION
This package can use VS Code themes to render code blocks that look like
VS Code. This offers more options for themes, tends to look a bit nicer,
and will probably be more familiar to most people.

It also does it's work during the Gatsby compile step so it shouldn't
slow down end-users.

There are so pages where basic `bash` code fences don't look great; it
may be worth trying more themes out.

* Adds `gatsby-remark-vscode`
* Adds `vscode-themes` package to use `Tomorrow` theme
* Removes `gatsby-remark-prismjs`

Here's what things currently look like now:

![Screen Shot 2020-07-20 at 8 40 15 PM](https://user-images.githubusercontent.com/691365/87999587-4f8b7c00-cac9-11ea-898c-1bafdb534e7a.png)
