### PR TITLE
(site) Adds link to edit post in GitHub

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,7 +3,8 @@ module.exports = {
     title: "TroyProg",
     description:
       "This is the personal site for Troy Rosenberg - engineering manager and develop. This serves as a place to store blog posts that are generally about technology. Topics may include - Ruby, Ruby on Rails, Elixir, Phoenix, JavaScript, TypeScript, Node, project management, engineering mangement, and more!",
-    author: "Troy Rosenberg (@tmr08c)"
+    author: "Troy Rosenberg (@tmr08c)",
+    repsitory: "https://github.com/tmr08c/tmr08c.github.io"
   },
   plugins: [
     {

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -7,13 +7,13 @@ interface BlogPostTemplateProps {
   data: {
     site: {
       siteMetadata: {
-        title: string;
+        repsitory: string;
       };
     };
     markdownRemark: {
       id: string;
-      excerpt: string;
       html: string;
+      excerpt: string;
       frontmatter: {
         title: string;
         date: string;
@@ -23,13 +23,36 @@ interface BlogPostTemplateProps {
   pageContext: {
     previous: any;
     next: any;
+    slug: string;
   };
+}
+
+const EditOnGitHubLink = ({ repoLink, postSlug} : { repoLink: string, postSlug: string}) => {
+  const linkToPostInRepo = `${repoLink}/tree/develop/content/blog/${postSlug}index.md`
+  const linkToIssues = `${repoLink}/issues`
+
+  return (
+    <div className="text-center font-light text-sm text-gray-600 italic mb-3">
+      Notice something wrong? You can{' '}
+
+      <a href={linkToPostInRepo} target="_blank" rel="noopener noreferrer" className="underline hover:text-living-coral-500">
+        propose an edit
+      </a>
+
+      {' '}or{' '}
+
+      <a href={linkToIssues} target="_blank" rel="noopener noreferrer" className="underline hover:text-living-coral-500">
+        open an issue
+      </a>.
+    </div>
+  )
 }
 
 class BlogPostTemplate extends React.Component<BlogPostTemplateProps, {}> {
   render() {
     const post = this.props.data.markdownRemark;
-    const { previous, next } = this.props.pageContext;
+    const { slug, previous, next } = this.props.pageContext;
+    const repoLink = this.props.data.site.siteMetadata.repsitory
 
     return (
       <Layout>
@@ -54,7 +77,10 @@ class BlogPostTemplate extends React.Component<BlogPostTemplateProps, {}> {
             marginBottom: "14px"
           }}
         />
-        <ul className="flex flex-wrap justify-between">
+
+        <EditOnGitHubLink repoLink={repoLink} postSlug={slug} />
+
+        <ul className="text-gray-600 flex flex-wrap justify-between">
           <li>
             {previous && (
               <Link to={previous.fields.slug} rel="prev">
@@ -84,8 +110,7 @@ export const pageQuery = graphql`
   query BlogPostBySlug($slug: String!) {
     site {
       siteMetadata {
-        title
-        author
+        repsitory
       }
     }
     markdownRemark(fields: { slug: { eq: $slug } }) {


### PR DESCRIPTION
Closes #79 

* Adds a link to the main repsitory in gatsby-config so we can pull it
  out in siteMetadata
* Creates a EditOnGitHubLink component that will have links to the blog
  post or new issue page on GitHub
* Also makes a small tweak or two around unused query info for the blog
  post template

![Screen Shot 2020-08-04 at 7 11 51 PM](https://user-images.githubusercontent.com/691365/89354270-6bc11880-d686-11ea-9b86-3b85ab9506f2.png)
