### PR TITLE
(site) Fixes config for `gatsby-plugin-manifest`

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -67,7 +67,8 @@ module.exports = {
       options: {
         name: "troy-prog-blog",
         short_name: "troyprog",
-        start_url: "/"
+        start_url: "/",
+        icon: "src/images/RhiDesign\ Troy\ Avatar.png"
       }
     },
     "gatsby-plugin-offline",


### PR DESCRIPTION
The `icon` (or `icons`) option is required. Adds avatar as icon. It will
log a `warning` that it is not square, but it seems to be fine for now:

![Screen Shot 2020-11-30 at 6 20 56 AM](https://user-images.githubusercontent.com/691365/100604261-48287a80-32d4-11eb-9e78-bd8c1777426d.png)