### PR TITLE
(fix) Fix metadata for Compiling Erlang Doc post

### DIFF
--- a/content/blog/2022/09/compiling-erlang-documentation/index.md
+++ b/content/blog/2022/09/compiling-erlang-documentation/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Compiling Erlang Documentation"
-date: "2022-08-31T18:08:13.265Z"
+date: "2022-09-30T08:51:13.265Z"
 categories: ["erlang", "elixir", "asdf", "documentation"]
 ---
 


### PR DESCRIPTION
- update the file location to follow the year/month/post title flow
- update the timestamp in the post to match when it was actually posted