### PR TITLE
(site) Remove Ruby from tool-versions file

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,2 @@
-ruby 2.5.1
 nodejs 16.18.0
 python 2.7.16


### PR DESCRIPTION
I believe this was left in from when the site was built using Jekyll