### PR TITLE
fix: Hugo v0.160+ compat — replace removed .Site.Author

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,16 @@ jobs:
           submodules: recursive
           fetch-depth: 0
       
+      - name: Read Hugo version from .tool-versions
+        id: hugo-version
+        run: |
+          HUGO_VERSION=$(grep hugo hugo-site/.tool-versions | awk '{print $2}')
+          echo "HUGO_VERSION=${HUGO_VERSION}" >> $GITHUB_OUTPUT
+
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: 'latest'
+          hugo-version: '${{ steps.hugo-version.outputs.HUGO_VERSION }}'
           extended: true
       
       - name: Setup Node.js

--- a/hugo-site/layouts/_default/baseof.html
+++ b/hugo-site/layouts/_default/baseof.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <!-- author -->
-  <meta name="author" content="{{ .Site.Author.name }}">
+  <meta name="author" content="{{ .Site.Params.author }}">
 
   <!-- description -->
   {{ if .Description }}


### PR DESCRIPTION
## Summary
- Replace deprecated `.Site.Author.name` with `.Site.Params.author` in `baseof.html` (removed in Hugo v0.160.0)
- Pin CI Hugo version to `.tool-versions` instead of `latest` to prevent future breakage (matches the deploy workflow)

## Test plan
- [ ] CI build passes with the pinned Hugo version
- [ ] Author meta tag renders correctly on the deployed site

🤖 Generated with [Claude Code](https://claude.com/claude-code)